### PR TITLE
eclualint usability improvements

### DIFF
--- a/eclualint
+++ b/eclualint
@@ -7,9 +7,14 @@ popd >/dev/null 2>&1
 srcdir="$ECSRCDIR"
 if [ -z "$srcdir" ]; then
   # See if we're in a source directory already.
-  if [ -x $(pwd)/modules/scriptlets/exe/eclua ]; then
-    srcdir=$(pwd)
-  fi
+  searchdir=$(pwd)
+  while [ "$searchdir" != "/" ]; do
+    if [ -x "$searchdir/modules/scriptlets/exe/eclua" ]; then
+      srcdir="$searchdir"
+      break
+    fi
+    searchdir=$(dirname $searchdir)
+  done
 fi
 
 if [ -z "$srcdir" ]; then

--- a/lualint
+++ b/lualint
@@ -166,10 +166,6 @@ local function scanfile(filename)
 
   local context, curfunc
 
-  if not fileexists(filename) then
-    return nil, "file "..filename.." does not exist"
-  end
-
   -- Ignore DSOs
   if filename:match("%.so$") then
     return true, {}, {}, {}
@@ -282,6 +278,12 @@ local function print_lint_output()
 end
 
 local function lint(filename, relaxed)
+  if not fileexists(filename) then
+    -- Warn but ignore files that don't exist
+    lint_output(filename, 1, "*** could not parse: file "..filename.." does not exist")
+    return
+  end
+
   local modules, declared, lint_ignored, refs = scanfile(filename)
 
   if not modules then


### PR DESCRIPTION
Ignore files that don't exist. Before this threw an error (non-zero exit status):

```
[rdawe@redacted]$ eclualint doesnotexist.lua

[Tue 06 Feb 2018 10:19:32] <0x276b780> scriptlet: doesnotexist.lua:1: *** could not parse: file doesnotexist.lua does not exist
[rdawe@redacted]$ echo $?
3
```

Now it doesn't:

```
[rdawe@redacted]$ ~/src/lualint/eclualint doesnotexist.lua

[Tue 06 Feb 2018 10:19:44] <0x161f780> scriptlet: doesnotexist.lua:1: *** could not parse: file doesnotexist.lua does not exist
[rdawe@redacted]$ echo $?
0
```